### PR TITLE
feat: Deserialize device subclasses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
 ]
-dependencies = ["Pyro5", "pymmcore-plus[cli]", "msgpack", "msgpack-numpy"]
+dependencies = ["Pyro5", "pymmcore-plus[cli]>=0.14.0", "msgpack", "msgpack-numpy"]
 
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
 [project.optional-dependencies]

--- a/src/pymmcore_remote/_serialize.py
+++ b/src/pymmcore_remote/_serialize.py
@@ -159,10 +159,6 @@ class SerDevice(Serializer[Device]):
 
         return {
             "device_label": obj.label,
-            "adapter_name": obj._adapter_name,
-            "device_name": obj._device_name,
-            "type": obj._type,
-            "description": obj._description,
             "core_uri": GLOBAL_DAEMON and GLOBAL_DAEMON.uriFor(CORE_NAME),
         }
 
@@ -171,7 +167,7 @@ class SerDevice(Serializer[Device]):
 
         core_uri = d.pop("core_uri")
         core = MMCorePlusProxy.instance(core_uri)
-        return Device(**d, mmcore=core)
+        return Device.create(d["device_label"], mmcore=core)
 
 
 class SerRePattern(Serializer[re.Pattern]):


### PR DESCRIPTION
Was checking this out (My experiments are [here](https://github.com/gselzer/pymmcore-remote-sandbox)) as this project may be useful for our lab. 

The current `SerDevice` always deserializes `Device`s to a `Device` object, even when the source may have been a subclass. Using `Device.create()` instead will return a subclass if the original device label belonged to a subclass.

Notably, as a result, we don't need to pass nearly as many fields explicitly. This could be annoying since it will mean more implicit traffic to obtain those other fields. Happy to discuss other alternatives if people see this as a problem, but we could also go with this approach until that problem realizes.