### PR TITLE
fix: MDA example

### DIFF
--- a/examples/remote_mda.py
+++ b/examples/remote_mda.py
@@ -1,15 +1,14 @@
 import numpy as np
 from useq import MDAEvent, MDASequence, TIntervalLoops
 
-from pymmcore_remote import MMCorePlusProxy, server, server_process
+from pymmcore_remote import MMCorePlusProxy, server_process
 
 PORT = 55999
 
 # this context manager ensures a server is running, or creates a new one if not.
 with server_process(port=PORT):
-    uri = f"PYRO:{server.CORE_NAME}@{server.DEFAULT_HOST}:{PORT}"
     # create a proxy object that communicates with the MMCore object on the server
-    with MMCorePlusProxy(uri=uri) as core:
+    with MMCorePlusProxy(port=PORT) as core:
         # continue using core as usual:
         core.loadSystemConfiguration()
 

--- a/examples/remote_mda.py
+++ b/examples/remote_mda.py
@@ -1,14 +1,15 @@
 import numpy as np
 from useq import MDAEvent, MDASequence, TIntervalLoops
 
-from pymmcore_remote import MMCorePlusProxy, server_process
+from pymmcore_remote import MMCorePlusProxy, server, server_process
 
 PORT = 55999
 
 # this context manager ensures a server is running, or creates a new one if not.
 with server_process(port=PORT):
+    uri = f"PYRO:{server.CORE_NAME}@{server.DEFAULT_HOST}:{PORT}"
     # create a proxy object that communicates with the MMCore object on the server
-    with MMCorePlusProxy(port=PORT) as core:
+    with MMCorePlusProxy(uri=uri) as core:
         # continue using core as usual:
         core.loadSystemConfiguration()
 

--- a/src/pymmcore_remote/client.py
+++ b/src/pymmcore_remote/client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import threading
-from typing import TYPE_CHECKING, Any, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast, overload
 
 import Pyro5.api
 import Pyro5.errors
@@ -46,11 +46,37 @@ class MMCorePlusProxy(Pyro5.api.Proxy):
             cls._instances[str(uri)] = cls(uri)
         return cls._instances[str(uri)]
 
+    @overload
     def __init__(
-        self, uri: Pyro5.api.URI | str | None = None, connected_socket: Any = None
+        self,
+        *,
+        port: int,
+        object_id: str | None = None,
+        host: str | None = None,
+        connected_socket: Any = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        uri: Pyro5.api.URI | str,
+        *,
+        connected_socket: Any = None,
+    ) -> None: ...
+
+    def __init__(
+        self,
+        uri: Pyro5.api.URI | str | None = None,
+        *,
+        object_id: str | None = None,
+        host: str | None = None,
+        port: int | None = None,
+        connected_socket: Any = None,
     ) -> None:
         if uri is None:
-            uri = f"PYRO:{server.CORE_NAME}@{server.DEFAULT_HOST}:{server.DEFAULT_PORT}"
+            object_id = server.CORE_NAME if object_id is None else object_id
+            host = server.DEFAULT_HOST if host is None else host
+            port = server.DEFAULT_PORT if port is None else port
+            uri = f"PYRO:{object_id}@{host}:{port}"
         register_serializers()
         super().__init__(uri, connected_socket=connected_socket)
         self._instances[str(self._pyroUri)] = self


### PR DESCRIPTION
MDA example did not run because no `port` kwarg was exposed.

Added a couple overloads such that the user can pass:
* `port` (optionally `object_id` and `host`) - enables the example again
* `uri`, which just combines the three.

Thoughts @tlambert03?